### PR TITLE
Convert p7/p8 to PEM

### DIFF
--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PolymorphicPseudonymisation.Utilities;
+using System;
 using System.Globalization;
 using System.IO;
 
@@ -41,7 +42,7 @@ namespace PolymorphicPseudonymisation.Tests.Utilities
 
                 var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
 
-                Assert.AreEqual(expected, actual, $"Test case {testCase} failed");
+                Assert.IsTrue(string.Equals(expected, actual, StringComparison.InvariantCulture), $"Test case {testCase} failed");
 
             }
         }

--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -41,7 +41,7 @@ namespace PolymorphicPseudonymisation.Tests.Utilities
 
                 var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
 
-                Assert.AreEqual(expected, actual, false, CultureInfo.InvariantCulture, $"Test case {testCase} failed");
+                Assert.AreEqual(expected, actual, $"Test case {testCase} failed");
 
             }
         }

--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PolymorphicPseudonymisation.Utilities;
+using System.Globalization;
 using System.IO;
 
 namespace PolymorphicPseudonymisation.Tests.Utilities
@@ -40,7 +41,7 @@ namespace PolymorphicPseudonymisation.Tests.Utilities
 
                 var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
 
-                Assert.AreEqual(expected, actual);
+                Assert.AreEqual(expected, actual, false, CultureInfo.InvariantCulture, $"Test case {testCase} failed");
 
             }
         }

--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -3,6 +3,7 @@ using PolymorphicPseudonymisation.Utilities;
 using System;
 using System.Globalization;
 using System.IO;
+using System.Text;
 
 namespace PolymorphicPseudonymisation.Tests.Utilities
 {
@@ -38,11 +39,11 @@ namespace PolymorphicPseudonymisation.Tests.Utilities
             for (var testCase = 0; testCase < inputs.Length; testCase+=1)
             {
                 var p7Data = File.ReadAllBytes(inputs[testCase]);
-                var expected = File.ReadAllText(expectedOutputs[testCase]);
+                var expected = File.ReadAllText(expectedOutputs[testCase], Encoding.ASCII);
 
                 var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
 
-                Assert.AreEqual(expected.GetHashCode(StringComparison.OrdinalIgnoreCase), actual.GetHashCode(StringComparison.OrdinalIgnoreCase), $"Test case {testCase} failed");
+                Assert.AreEqual(expected, actual, $"Test case {testCase} failed");
 
             }
         }

--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -42,7 +42,7 @@ namespace PolymorphicPseudonymisation.Tests.Utilities
 
                 var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
 
-                Assert.IsTrue(string.Equals(expected, actual, StringComparison.InvariantCulture), $"Test case {testCase} failed");
+                Assert.AreEqual(expected.GetHashCode(StringComparison.OrdinalIgnoreCase), actual.GetHashCode(StringComparison.OrdinalIgnoreCase), $"Test case {testCase} failed");
 
             }
         }

--- a/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
+++ b/PolymorphicPseudonymisation.Tests/Utilities/PemReaderTests.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PolymorphicPseudonymisation.Utilities;
+using System.IO;
+
+namespace PolymorphicPseudonymisation.Tests.Utilities
+{
+    [TestClass]
+    [DeploymentItem("resources", "resources")]
+    public class PemReaderTests
+    {
+        [TestMethod]
+        public void ShouldDecryptPems()
+        {
+            var p8Data = File.ReadAllBytes("resources/private.p8");
+            var certData = File.ReadAllBytes("resources/cert.pem");
+
+            var inputs = new[]
+            {
+                "resources/p7/ID-4.p7",
+                "resources/p7/ID-5.p7",
+                "resources/p7/PC-4.p7",
+                "resources/p7/PC-5.p7",
+                "resources/p7/PD-4.p7",
+                "resources/p7/PD-5.p7"
+            };
+            var expectedOutputs = new[]
+            {
+                "resources/keys/id-4.pem",
+                "resources/keys/id-5.pem",
+                "resources/keys/pc-4.pem",
+                "resources/keys/pc-5.pem",
+                "resources/keys/pd-4.pem",
+                "resources/keys/pd-5.pem"
+            };
+
+            for (var testCase = 0; testCase < inputs.Length; testCase+=1)
+            {
+                var p7Data = File.ReadAllBytes(inputs[testCase]);
+                var expected = File.ReadAllText(expectedOutputs[testCase]);
+
+                var actual = PemReader.DecryptPem(p7Data, p8Data, certData);
+
+                Assert.AreEqual(expected, actual);
+
+            }
+        }
+    }
+}

--- a/PolymorphicPseudonymisation/PolymorphicPseudonymisation.csproj
+++ b/PolymorphicPseudonymisation/PolymorphicPseudonymisation.csproj
@@ -27,7 +27,6 @@ v1.0.0 Initial release.</PackageReleaseNotes>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
   </ItemGroup>
 

--- a/PolymorphicPseudonymisation/PolymorphicPseudonymisation.csproj
+++ b/PolymorphicPseudonymisation/PolymorphicPseudonymisation.csproj
@@ -27,6 +27,7 @@ v1.0.0 Initial release.</PackageReleaseNotes>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
   </ItemGroup>
 

--- a/PolymorphicPseudonymisation/Utilities/PemReader.cs
+++ b/PolymorphicPseudonymisation/Utilities/PemReader.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -11,19 +9,10 @@ namespace PolymorphicPseudonymisation.Utilities
     {
         public static string DecryptPem(byte[] p7Data, byte[] p8Data, byte[] certData)
         {
-            using CngKey key = CngKey.Import(p8Data, CngKeyBlobFormat.Pkcs8PrivateBlob);
-
-            // The export policy needs to be redefined because CopyWithPrivateKey
-            // needs to export/re-import ephemeral keys
-            key.SetProperty(
-                new CngProperty(
-                    "Export Policy",
-                    BitConverter.GetBytes((int)CngExportPolicies.AllowPlaintextExport),
-                    CngPropertyOptions.Persist));
-
-            using RSA rsa = new RSACng(key);
-            using X509Certificate2 cert = new X509Certificate2(certData);
-            using X509Certificate2 certWithKey = cert.CopyWithPrivateKey(rsa);
+            using var rsa = RSA.Create();
+            rsa.ImportPkcs8PrivateKey(p8Data, out int _);
+            using var cert = new X509Certificate2(certData);
+            using var certWithKey = cert.CopyWithPrivateKey(rsa);
 
             EnvelopedCms cms = new EnvelopedCms();
             cms.Decode(p7Data);

--- a/PolymorphicPseudonymisation/Utilities/PemReader.cs
+++ b/PolymorphicPseudonymisation/Utilities/PemReader.cs
@@ -19,7 +19,7 @@ namespace PolymorphicPseudonymisation.Utilities
             cms.Decrypt(new X509Certificate2Collection(certWithKey));
 
             var content = cms.ContentInfo.Content;
-            var pemData = Encoding.UTF8.GetString(content);
+            var pemData = Encoding.ASCII.GetString(content);
 
             return pemData;
         }

--- a/PolymorphicPseudonymisation/Utilities/PemReader.cs
+++ b/PolymorphicPseudonymisation/Utilities/PemReader.cs
@@ -19,7 +19,7 @@ namespace PolymorphicPseudonymisation.Utilities
             cms.Decrypt(new X509Certificate2Collection(certWithKey));
 
             var content = cms.ContentInfo.Content;
-            var pemData = Encoding.ASCII.GetString(content);
+            var pemData = Encoding.UTF8.GetString(content);
 
             return pemData;
         }

--- a/PolymorphicPseudonymisation/Utilities/PemReader.cs
+++ b/PolymorphicPseudonymisation/Utilities/PemReader.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace PolymorphicPseudonymisation.Utilities
+{
+    public static class PemReader
+    {
+        public static string DecryptPem(byte[] p7Data, byte[] p8Data, byte[] certData)
+        {
+            using CngKey key = CngKey.Import(p8Data, CngKeyBlobFormat.Pkcs8PrivateBlob);
+
+            // The export policy needs to be redefined because CopyWithPrivateKey
+            // needs to export/re-import ephemeral keys
+            key.SetProperty(
+                new CngProperty(
+                    "Export Policy",
+                    BitConverter.GetBytes((int)CngExportPolicies.AllowPlaintextExport),
+                    CngPropertyOptions.Persist));
+
+            using RSA rsa = new RSACng(key);
+            using X509Certificate2 cert = new X509Certificate2(certData);
+            using X509Certificate2 certWithKey = cert.CopyWithPrivateKey(rsa);
+
+            EnvelopedCms cms = new EnvelopedCms();
+            cms.Decode(p7Data);
+            cms.Decrypt(new X509Certificate2Collection(certWithKey));
+
+            var content = cms.ContentInfo.Content;
+            var pemData = Encoding.ASCII.GetString(content);
+
+            return pemData;
+        }
+    }
+}


### PR DESCRIPTION
Implementing #2 
Converting the p7 and p8 files to PEM ourselves so the consumer is not require to manually do this using openssl before being able to use the library.